### PR TITLE
Add specific personal access token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,4 +46,4 @@ jobs:
       - name: Run semantic release
         run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_DEPLOYMENT_TOKEN }}


### PR DESCRIPTION
@soanvig we need to add secret `GITHUB_PERSONAL_ACCESS_TOKEN` with personal access token. Scope: all from `repo` section. Unfortunately using `GITHUB_TOKEN` doesn't trigger `release:published` event. 😔