### PR TITLE
fix: production build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,20 +20,19 @@ COPY yarn.lock .
 
 FROM install as build
 
-COPY . .
-
 RUN yarn install --frozen-lockfile && yarn cache clean
+
+COPY . .
 
 RUN yarn build
 
-FROM node:14.16.0-buster-slim@sha256:ffc15488e56d99dbc9b90d496aaf47901c6a940c077bc542f675ae351e769a12 as production-build
+CMD node build/index.js
+
+FROM install as production-build
 
 WORKDIR /app
 
 ENV NODE_ENV=production
-
-COPY package.json ./
-COPY yarn.lock ./
 
 COPY --from=build /app/build /app/build
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,8 @@ curl -d '{"html":"<strong>Hello world</strong>"}' -H "Content-Type: application/
 
 **Remember to select precise version tag for the image (e.g. leocode/puppeteer-service:1.1.0)**
 
-Default `latest` tag is built out of master, which means it is cutting-edge version.
-
 ```
-docker build leocode/puppeteer-service
+docker run leocode/puppeteer-service
 ```
 
 The same can be used for docker-compose:
@@ -144,10 +142,16 @@ Dependencies:
 - Docker
 
 ```
-yarn start
+yarn start:dev
 ```
 
 Start container with API. Wait until logs from server appear (due to one-line command `docker build` output is muted). It may take up to few minutes. Consecutive starts (after code change) should be faster.
+
+You can test production build using
+
+```
+yarn start:prod
+```
 
 ### Versioning
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "puppeteer-service",
   "version": "1.0.0",
   "scripts": {
-    "start": "docker run --rm -it -p 3000:3000 $(docker build -q .)",
+    "start:dev": "docker run --rm -it -p 3000:3000 $(docker build --target build -q .)",
+    "start:prod": "docker run --rm -it -p 3000:3000 $(docker build -q .)",
     "start:local": "node build/index.js",
     "build": "tsc",
     "test": "jest",


### PR DESCRIPTION
I optimized Dockerfile a little, so restarts during development don't reinstall everything.

Production build was failing because it was built out of fresh node image without puppeteer from first step